### PR TITLE
Latest dart updates

### DIFF
--- a/hexapod_dart/README.md
+++ b/hexapod_dart/README.md
@@ -93,34 +93,25 @@ def check_hexapod_dart(conf):
     # You can customize where you want to check
     # e.g. here we search also in a folder defined by an environmental variable
     if 'RESIBOTS_DIR' in os.environ:
-      includes_check = [os.environ['RESIBOTS_DIR'] + '/include'] + includes_check
-      libs_check = [os.environ['RESIBOTS_DIR'] + '/lib'] + libs_check
+    	includes_check = [os.environ['RESIBOTS_DIR'] + '/include'] + includes_check
+    	libs_check = [os.environ['RESIBOTS_DIR'] + '/lib'] + libs_check
 
     if conf.options.hexapod_dart:
-      includes_check = [conf.options.hexapod_dart + '/include']
-      libs_check = [conf.options.hexapod_dart + '/lib']
+    	includes_check = [conf.options.hexapod_dart + '/include']
+    	libs_check = [conf.options.hexapod_dart + '/lib']
 
     try:
-      conf.start_msg('Checking for hexapod_dart includes')
-      res = conf.find_file('hexapod_dart/hexapod.hpp', includes_check)
-      res = res and conf.find_file('hexapod_dart/hexapod_control.hpp', includes_check)
-      res = res and conf.find_file('hexapod_dart/hexapod_dart_simu.hpp', includes_check)
-      conf.end_msg('ok')
-      conf.start_msg('Checking for hexapod_dart libs')
-      res = res and conf.find_file('libhexapod_dart.a', libs_check)
-      conf.end_msg('ok')
-      conf.env.INCLUDES_HEXAPOD_DART = includes_check
-      conf.env.STLIBPATH_HEXAPOD_DART = libs_check
-      conf.env.STLIB_HEXAPOD_DART = ['hexapod_dart']
-      conf.start_msg('Checking for hexapod_dart graphics libs')
-      res = res and conf.find_file('libhexapod_dart_graphic.a', libs_check)
-      conf.end_msg('ok')
-      conf.env.INCLUDES_HEXAPOD_DART_GRAPHIC = conf.env.INCLUDES_HEXAPOD_DART
-      conf.env.STLIBPATH_HEXAPOD_DART_GRAPHIC = conf.env.STLIBPATH_HEXAPOD_DART
-      conf.env.STLIB_HEXAPOD_DART_GRAPHIC = ['hexapod_dart_graphic']
+    	conf.start_msg('Checking for hexapod_dart includes')
+    	res = conf.find_file('hexapod_dart/hexapod.hpp', includes_check)
+    	res = res and conf.find_file('hexapod_dart/hexapod_control.hpp', includes_check)
+    	res = res and conf.find_file('hexapod_dart/hexapod_dart_simu.hpp', includes_check)
+    	res = res and conf.find_file('hexapod_dart/descriptors.hpp', includes_check)
+    	res = res and conf.find_file('hexapod_dart/safety_measures.hpp', includes_check)
+    	conf.end_msg('ok')
+    	conf.env.INCLUDES_HEXAPOD_DART = includes_check
     except:
-      conf.end_msg('Not found', 'RED')
-      return
+    	conf.end_msg('Not found', 'RED')
+    	return
     return 1
 ```
 

--- a/hexapod_dart/include/hexapod_dart/descriptors.hpp
+++ b/hexapod_dart/include/hexapod_dart/descriptors.hpp
@@ -41,6 +41,7 @@ namespace hexapod_dart {
             template <typename Simu, typename robot>
             void operator()(Simu& simu, std::shared_ptr<robot> rob, const Eigen::Vector6d& init_trans)
             {
+                const dart::collision::CollisionResult& col_res = simu.world()->getLastCollisionResult();
                 for (size_t i = 0; i < 6; ++i) {
                     std::string leg_name = "leg_" + std::to_string(i) + "_3";
                     dart::dynamics::BodyNodePtr body_to_check;
@@ -54,7 +55,7 @@ namespace hexapod_dart {
                         _contacts[i].push_back(0);
                     }
                     else {
-                        _contacts[i].push_back(body_to_check->isColliding());
+                        _contacts[i].push_back(col_res.inCollision(body_to_check));
                     }
                 }
             }

--- a/hexapod_dart/include/hexapod_dart/hexapod.hpp
+++ b/hexapod_dart/include/hexapod_dart/hexapod.hpp
@@ -2,6 +2,7 @@
 #define HEXAPOD_DART_HEXAPOD_HPP
 
 #include <dart/dart.h>
+#include <dart/utils/urdf/urdf.h>
 #include <Eigen/Core>
 #include <string>
 #include <fstream>

--- a/hexapod_dart/include/hexapod_dart/hexapod_control.hpp
+++ b/hexapod_dart/include/hexapod_dart/hexapod_control.hpp
@@ -62,7 +62,7 @@ namespace hexapod_dart {
             Eigen::VectorXd q = _robot->skeleton()->getPositions();
             Eigen::VectorXd q_err = _target_positions - q;
 
-            double gain = 1.0 / (DART_PI * _robot->skeleton()->getTimeStep());
+            double gain = 1.0 / (dart::math::constants<double>::pi() * _robot->skeleton()->getTimeStep());
             Eigen::VectorXd vel = q_err * gain;
             vel = vel.cwiseProduct(_p);
 

--- a/hexapod_dart/include/hexapod_dart/hexapod_dart_simu.hpp
+++ b/hexapod_dart/include/hexapod_dart/hexapod_dart_simu.hpp
@@ -16,7 +16,7 @@
 #include <hexapod_dart/descriptors.hpp>
 
 #ifdef GRAPHIC
-#include <osgDart/osgDart.h>
+#include <dart/gui/osg/osg.h>
 #endif
 
 namespace hexapod_dart {
@@ -69,7 +69,7 @@ namespace hexapod_dart {
                                                                           _desc_period(2),
                                                                           _break(false)
         {
-            _world->getConstraintSolver()->setCollisionDetector(std::unique_ptr<dart::collision::DARTCollisionDetector>(new dart::collision::DARTCollisionDetector()));
+            _world->getConstraintSolver()->setCollisionDetector(dart::collision::DARTCollisionDetector::create());
             _robot = robot;
             // set position of hexapod
             _robot->skeleton()->setPosition(5, 0.2);
@@ -84,7 +84,7 @@ namespace hexapod_dart {
             _controller.set_parameters(ctrl);
 
 #ifdef GRAPHIC
-            _osg_world_node = new osgDart::WorldNode(_world);
+            _osg_world_node = new dart::gui::osg::WorldNode(_world);
             _osg_world_node->simulate(true);
             _osg_viewer.addWorldNode(_osg_world_node);
             _osg_viewer.setUpViewInWindow(0, 0, 640, 480);
@@ -329,8 +329,8 @@ namespace hexapod_dart {
         safety_measures_t _safety_measures;
         descriptors_t _descriptors;
 #ifdef GRAPHIC
-        osg::ref_ptr<osgDart::WorldNode> _osg_world_node;
-        osgDart::Viewer _osg_viewer;
+        osg::ref_ptr<dart::gui::osg::WorldNode> _osg_world_node;
+        dart::gui::osg::Viewer _osg_viewer;
 #endif
     };
 }

--- a/hexapod_dart/include/hexapod_dart/safety_measures.hpp
+++ b/hexapod_dart/include/hexapod_dart/safety_measures.hpp
@@ -39,7 +39,7 @@ namespace hexapod_dart {
                 Eigen::Vector3d z_axis = {0.0, 0.0, 1.0};
                 Eigen::Vector3d robot_z_axis = rot_mat * z_axis;
                 double z_angle = std::atan2((z_axis.cross(robot_z_axis)).norm(), z_axis.dot(robot_z_axis));
-                if (std::abs(z_angle) >= DART_PI_HALF)
+                if (std::abs(z_angle) >= dart::math::constants<double>::half_pi())
                     simu.stop_sim();
             }
 

--- a/hexapod_dart/waf_tools/dart.py
+++ b/hexapod_dart/waf_tools/dart.py
@@ -57,11 +57,21 @@ def check_dart(conf):
 	except:
 		osg_found = False
 
+	extra_libs = []
+
 	try:
-		conf.start_msg('Checking for DART includes')
+		conf.start_msg('Checking for DART includes (including utils/urdf)')
 		res = conf.find_file('dart/dart.h', includes_check)
-		res = res and conf.find_file('dart/dart-core.h', includes_check)
+		res = res and conf.find_file('dart/utils/utils.h', includes_check)
+		res = res and conf.find_file('dart/utils/urdf/urdf.h', includes_check)
 		conf.end_msg('ok')
+		try:
+			conf.start_msg('Checking for DART gui includes')
+			res = res and conf.find_file('dart/gui/gui.h', includes_check)
+			res = res and conf.find_file('dart/gui/osg/osg.h', includes_check)
+			conf.end_msg('ok')
+		except:
+			conf.end_msg('Not found', 'RED')
 		conf.start_msg('DART: Checking for optional Bullet includes')
 		more_includes = []
 		if bullet_found:
@@ -71,13 +81,23 @@ def check_dart(conf):
 			conf.end_msg('Not found - be sure that your DART installation is without Bullet enabled', 'RED')
 		if assimp_found:
 			more_includes += assimp_check
-		conf.start_msg('Checking for DART libs')
+		conf.start_msg('Checking for DART libs (including utils/urdf)')
 		res = res and conf.find_file('libdart.so', libs_check)
-		res = res and conf.find_file('libdart-core.so', libs_check)
+		res = res and conf.find_file('libdart-utils.so', libs_check)
+		res = res and conf.find_file('libdart-utils-urdf.so', libs_check)
 		conf.end_msg('ok')
+		try:
+			conf.start_msg('Checking for DART gui libs')
+			res = res and conf.find_file('libdart-gui.so', libs_check)
+			res = res and conf.find_file('libdart-gui-osg.so', libs_check)
+			conf.end_msg('ok')
+			extra_libs.append('dart-gui')
+			extra_libs.append('dart-gui-osg')
+		except:
+			conf.end_msg('Not found', 'RED')
 		conf.env.INCLUDES_DART = includes_check + more_includes
 		conf.env.LIBPATH_DART = libs_check
-		conf.env.LIB_DART = ['dart', 'dart-core']
+		conf.env.LIB_DART = ['dart', 'dart-utils', 'dart-utils-urdf'] + extra_libs
 		conf.start_msg('DART: Checking for Assimp')
 		if assimp_found:
 			conf.end_msg('ok')
@@ -88,15 +108,9 @@ def check_dart(conf):
 		if bullet_found:
 			conf.env.LIB_DART.append('BulletCollision')
 			conf.env.LIB_DART.append('LinearMath')
-		conf.start_msg('Checking for DART OSG includes (optional)')
-		res = res and conf.find_file('osgDart/osgDart.h', includes_check)
-		conf.end_msg('ok')
-		conf.start_msg('Checking for DART OSG libs (optional)')
-		res = res and conf.find_file('libosgDart.so', libs_check)
-		conf.end_msg('ok')
 		conf.env.INCLUDES_DART_GRAPHIC = conf.env.INCLUDES_DART
 		conf.env.LIBPATH_DART_GRAPHIC = conf.env.LIBPATH_DART
-		conf.env.LIB_DART_GRAPHIC = conf.env.LIB_DART + ['osgDart']
+		conf.env.LIB_DART_GRAPHIC = conf.env.LIB_DART
 		conf.start_msg('DART: Checking for OSG (optional)')
 		if osg_found:
 			conf.env.INCLUDES_DART_GRAPHIC += osg_check

--- a/hexapod_dart/waf_tools/dart.py
+++ b/hexapod_dart/waf_tools/dart.py
@@ -57,8 +57,6 @@ def check_dart(conf):
 	except:
 		osg_found = False
 
-	extra_libs = []
-
 	try:
 		conf.start_msg('Checking for DART includes (including utils/urdf)')
 		res = conf.find_file('dart/dart.h', includes_check)
@@ -86,18 +84,9 @@ def check_dart(conf):
 		res = res and conf.find_file('libdart-utils.so', libs_check)
 		res = res and conf.find_file('libdart-utils-urdf.so', libs_check)
 		conf.end_msg('ok')
-		try:
-			conf.start_msg('Checking for DART gui libs')
-			res = res and conf.find_file('libdart-gui.so', libs_check)
-			res = res and conf.find_file('libdart-gui-osg.so', libs_check)
-			conf.end_msg('ok')
-			extra_libs.append('dart-gui')
-			extra_libs.append('dart-gui-osg')
-		except:
-			conf.end_msg('Not found', 'RED')
 		conf.env.INCLUDES_DART = includes_check + more_includes
 		conf.env.LIBPATH_DART = libs_check
-		conf.env.LIB_DART = ['dart', 'dart-utils', 'dart-utils-urdf'] + extra_libs
+		conf.env.LIB_DART = ['dart', 'dart-utils', 'dart-utils-urdf']
 		conf.start_msg('DART: Checking for Assimp')
 		if assimp_found:
 			conf.end_msg('ok')
@@ -108,18 +97,25 @@ def check_dart(conf):
 		if bullet_found:
 			conf.env.LIB_DART.append('BulletCollision')
 			conf.env.LIB_DART.append('LinearMath')
-		conf.env.INCLUDES_DART_GRAPHIC = conf.env.INCLUDES_DART
-		conf.env.LIBPATH_DART_GRAPHIC = conf.env.LIBPATH_DART
-		conf.env.LIB_DART_GRAPHIC = conf.env.LIB_DART
-		conf.start_msg('DART: Checking for OSG (optional)')
-		if osg_found:
-			conf.env.INCLUDES_DART_GRAPHIC += osg_check
-			conf.env.LIBPATH_DART_GRAPHIC += osg_libs
-			conf.env.LIB_DART_GRAPHIC += osg_comp
+		try:
+			conf.start_msg('Checking for DART gui libs')
+			res = res and conf.find_file('libdart-gui.so', libs_check)
+			res = res and conf.find_file('libdart-gui-osg.so', libs_check)
 			conf.end_msg('ok')
-		else:
-			conf.end_msg('Not found - Your graphical programs may not compile', 'RED')
-		conf.get_env()['BUILD_GRAPHIC'] = True
+			conf.env.INCLUDES_DART_GRAPHIC = conf.env.INCLUDES_DART
+			conf.env.LIBPATH_DART_GRAPHIC = conf.env.LIBPATH_DART
+			conf.env.LIB_DART_GRAPHIC = conf.env.LIB_DART + ['dart-gui', 'dart-gui-osg']
+			conf.start_msg('DART: Checking for OSG (optional)')
+			if osg_found:
+				conf.env.INCLUDES_DART_GRAPHIC += osg_check
+				conf.env.LIBPATH_DART_GRAPHIC += osg_libs
+				conf.env.LIB_DART_GRAPHIC += osg_comp
+				conf.end_msg('ok')
+			else:
+				conf.end_msg('Not found - Your graphical programs may not compile/link', 'RED')
+			conf.get_env()['BUILD_GRAPHIC'] = True
+		except:
+			conf.end_msg('Not found', 'RED')
 	except:
 		conf.end_msg('Not found', 'RED')
 		return

--- a/hexapod_dart/wscript
+++ b/hexapod_dart/wscript
@@ -65,8 +65,8 @@ def build(bld):
                       install_path = None,
                       source = 'src/test.cpp',
                       includes = './include',
-                      uselib = 'BOOST BOOST_SYSTEM BOOST_REGEX DART EIGEN HEXAPOD_CONTROLLER DART_GRAPHIC',
-                      cxxflags = ['-DGRAPHIC'],
+                      uselib = 'BOOST BOOST_SYSTEM BOOST_REGEX EIGEN HEXAPOD_CONTROLLER DART_GRAPHIC',
+                      defines = ['GRAPHIC'],
                       target = 'test')
 
     bld.program(features = 'cxx',


### PR DESCRIPTION
As we discussed, we should keep up to date with the DART master (as long as they do not break any functionality that we want) until the next release (should be 6.0).

This PR adapts for the current master branch of DART.. The main changes:
- Now DART is split into libraries (e.g. dart, dart-gui, dart-utils etc). So, I adapted the wscript file to find them correctly.
- Collision checking changed.
- DART now uses constants instead of typedefs for math constants..
