### PR TITLE
fix for segfault

### DIFF
--- a/hexapod_dart/wscript
+++ b/hexapod_dart/wscript
@@ -51,7 +51,7 @@ def configure(conf):
             common_flags = "-Wall -std=c++0x"
         else:
             common_flags = "-Wall -std=c++11"
-        opt_flags = " -O3 -march=native -g"
+        opt_flags = " -O3 -g"
 
     all_flags = common_flags + opt_flags
     conf.env['CXXFLAGS'] = conf.env['CXXFLAGS'] + all_flags.split(' ')


### PR DESCRIPTION
With the "-march=native" flag we get a segmentation fault on the cluster (gcc version 5.4.0 20160609). Without it, we don't.